### PR TITLE
fix(EC-14727): Improved BoundingBox Synchronization for Linked 3D Models

### DIFF
--- a/src/forge/footprintManager.ts
+++ b/src/forge/footprintManager.ts
@@ -16,6 +16,11 @@ export class FootprintManager {
                 this.updateLabelPositions(bbox[0], bbox[1]);
             }
         });
+        this.forgeContext.viewer.addEventListener(Autodesk.Viewing.GEOMETRY_LOADED_EVENT, () => {
+            if (this.isFootprintEnabled()) {
+               this.redraw();
+            }
+        });
 
         this.initializeUnitPickerElement();
     }


### PR DESCRIPTION
Fixed an issue where the bounding box of a 3D model would not accurately reflect the updated size when a linked 3D model was loaded. To resolve this, I have implemented an event listener that triggers a redraw of the bounding box upon loading a linked 3D model.