### PR TITLE
fix(EC-24213): Fix Camera "Nudge" by Preserving Viewport State

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfsquad/forge-viewer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -189,7 +189,7 @@ export class ForgeContext {
         this.setPivotPoint();
     }
 
-    private restoreState(targetState: ViewerState): Promise<void> {
+    private restoreState(targetState: ViewerState, options?: { preserveCamera?: boolean }): Promise<void> {
         // https://forge.autodesk.com/blog/wait-restorestate-finish
         var promise = new Promise<void>((resolve, _) => {
             var listener = (event: any) => {
@@ -208,8 +208,12 @@ export class ForgeContext {
                 listener
             );
 
-            this.viewer.restoreState(targetState);
+            // When preserveCamera is true, exclude viewport from restore to avoid
+            // overriding active camera transitions with intermediate states
+            const filter = options?.preserveCamera ? { viewport: false } : undefined;
+            this.viewer.restoreState(targetState, filter, false);
         });
+
 
         return promise;
     }
@@ -357,7 +361,10 @@ export class ForgeContext {
         for (const objSet of state.objectSet) {
             objSet.hidden = [];
         }
-        await this.restoreState(state);
+
+        // Preserve camera to avoid overriding active camera transitions
+        // with intermediate states captured during animation
+        await this.restoreState(state, { preserveCamera: true });
 
         let mapped3dItems = linked3dModel.mapped3dItems;
 


### PR DESCRIPTION
### PR Description: Fix Camera "Nudge" by Preserving Viewport State

This PR addresses the issue where the camera would drift or "nudge" during visibility updates. This occurred because the wrapper was capturing and restoring the complete viewer state (including intermediate camera positions) during animations.

### Key Changes

#### `ForgeContext.ts`
- **Updated `restoreState`**: Added an optional `preserveCamera` flag. When enabled, it applies the `{ viewport: false }` filter to the Forge Viewer's `restoreState` method, skipping camera restoration.
- **Updated `toggleInViewer`**: Now passes `{ preserveCamera: true }` when restoring state during visibility/layout changes.

### Result
Model visibility and layout updates can now proceed without interfering with active camera transitions or causing unintended movements.