### PR TITLE
fix: replace restoreState with cancellable camera animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfsquad/forge-viewer",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -136,6 +136,11 @@ export class ForgeContext {
                 return;
             }
 
+            // Cancel any in-flight camera animation so its per-frame
+            // renders don't trigger FINAL_FRAME_RENDERED_CHANGED_EVENT
+            // and prematurely resolve the restoreState in toggleInViewer.
+            this._cancelCameraAnimation?.();
+
             for (let configurationId of Object.keys(this.loaded3dModels)) {
                 if (!layout3d.some(l => l.configurationId == configurationId)) {
                     this.viewer.hideModel(this.loaded3dModels[configurationId].id);
@@ -265,6 +270,29 @@ export class ForgeContext {
         });
     }
 
+
+    private restoreState(targetState: ViewerState, options?: { preserveCamera?: boolean }): Promise<void> {
+        // https://forge.autodesk.com/blog/wait-restorestate-finish
+        return new Promise<void>((resolve) => {
+            const listener = (event: any) => {
+                if (event.value.finalFrame) {
+                    this.viewer.removeEventListener(
+                        Autodesk.Viewing.FINAL_FRAME_RENDERED_CHANGED_EVENT,
+                        listener
+                    );
+                    resolve();
+                }
+            };
+
+            this.viewer.addEventListener(
+                Autodesk.Viewing.FINAL_FRAME_RENDERED_CHANGED_EVENT,
+                listener
+            );
+
+            const filter = options?.preserveCamera ? { viewport: false } : undefined;
+            this.viewer.restoreState(targetState, filter, false);
+        });
+    }
 
     private _loadModelPromises: { [configurationId: string]: { resolve: any, reject: Function } } = {};
     private _loadModelSpinners: { [configurationId: string]: THREE.Object3D } = {};
@@ -405,40 +433,20 @@ export class ForgeContext {
     private async toggleInViewer(model: Autodesk.Viewing.Model, linked3dModel: Layout3d) {
         if (!this.viewer) { return; }
 
-        // Wait for the object tree to be mapped if it hasn't been yet.
-        // loadModel resolves before onObjectTreeCreated fires, so
-        // dbIdsByName may not be populated on first call.
-        if (!this.dbIdsByName[model.id]) {
-            await new Promise<void>((resolve) => {
-                const check = (e: any) => {
-                    if (e.model.id === model.id) {
-                        this.viewer.removeEventListener(Autodesk.Viewing.OBJECT_TREE_CREATED_EVENT, check);
-                        resolve();
-                    }
-                };
-                this.viewer.addEventListener(Autodesk.Viewing.OBJECT_TREE_CREATED_EVENT, check);
-            });
-        }
-
         const state = this.viewer.getState();
         for (const objSet of state.objectSet) {
             objSet.hidden = [];
         }
 
-        // Apply immediately (not animated) to avoid a race with
-        // animateCamera: an animated restoreState listens for
-        // FINAL_FRAME_RENDERED_CHANGED_EVENT which our camera animation
-        // can trigger, causing restoreState to resolve before the
-        // visibility reset completes — then its delayed completion
-        // overwrites the new visibility state we set next.
-        const filter = { viewport: false };
-        this.viewer.restoreState(state, filter, true);
+        // Preserve camera to avoid overriding active camera transitions
+        // with intermediate states captured during animation
+        await this.restoreState(state, { preserveCamera: true });
 
         let mapped3dItems = linked3dModel.mapped3dItems;
 
         this.moveModel(model, linked3dModel);
 
-        let instanceTree = model.getData().instanceTree;
+        let instanceTree = this.viewer.model.getData().instanceTree;
 
         for (let visibleItem of mapped3dItems.visibleItems) {
             let itemIds = this.dbIdsByName[model.id][visibleItem.toLowerCase()];
@@ -469,7 +477,7 @@ export class ForgeContext {
         }
         for (let fragId in this.originalColors) {
             let color = this.originalColors[fragId];
-            let material = (<any>model.getFragmentList()).getMaterial(fragId);
+            let material = (<any>this.viewer.model.getFragmentList()).getMaterial(fragId);
             material.color = color;
             material.needsUpdate = true;
         }
@@ -486,7 +494,7 @@ export class ForgeContext {
                     const frags = this.dbsToFrags([itemId]);
 
                     for (const fragId of frags) {
-                        let originalMaterial = (<any>model.getFragmentList()).getMaterial(fragId);
+                        let originalMaterial = (<any>this.viewer.model.getFragmentList()).getMaterial(fragId);
                         if (originalMaterial) {
                             if (!(fragId in this.originalMaterials)) {
                                 this.originalMaterials[fragId] = originalMaterial;

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -213,13 +213,6 @@ export class ForgeContext {
         const endTarget = new THREE.Vector3(target.target[0], target.target[1], target.target[2]);
         const endUp = new THREE.Vector3(target.up[0], target.up[1], target.up[2]);
 
-        if (startEye.distanceTo(endEye) < 0.01 && startTarget.distanceTo(endTarget) < 0.01) {
-            cam.up.copy(endUp);
-            nav.setPosition(endEye);
-            nav.setTarget(endTarget);
-            return Promise.resolve();
-        }
-
         return new Promise<void>((resolve) => {
             let cancelled = false;
             let rafId: number;
@@ -272,34 +265,6 @@ export class ForgeContext {
         });
     }
 
-    private restoreState(targetState: ViewerState, options?: { preserveCamera?: boolean }): Promise<void> {
-        // https://forge.autodesk.com/blog/wait-restorestate-finish
-        var promise = new Promise<void>((resolve, _) => {
-            var listener = (event: any) => {
-                if (event.value.finalFrame) {
-                    this.viewer.removeEventListener(
-                        Autodesk.Viewing.FINAL_FRAME_RENDERED_CHANGED_EVENT,
-                        listener
-                    );
-                    resolve();
-                }
-            }
-
-            // Wait for last render caused by camera changes
-            this.viewer.addEventListener(
-                Autodesk.Viewing.FINAL_FRAME_RENDERED_CHANGED_EVENT,
-                listener
-            );
-
-            // When preserveCamera is true, exclude viewport from restore to avoid
-            // overriding active camera transitions with intermediate states
-            const filter = options?.preserveCamera ? { viewport: false } : undefined;
-            this.viewer.restoreState(targetState, filter, false);
-        });
-
-
-        return promise;
-    }
 
     private _loadModelPromises: { [configurationId: string]: { resolve: any, reject: Function } } = {};
     private _loadModelSpinners: { [configurationId: string]: THREE.Object3D } = {};
@@ -445,9 +410,14 @@ export class ForgeContext {
             objSet.hidden = [];
         }
 
-        // Preserve camera to avoid overriding active camera transitions
-        // with intermediate states captured during animation
-        await this.restoreState(state, { preserveCamera: true });
+        // Apply immediately (not animated) to avoid a race with
+        // animateCamera: an animated restoreState listens for
+        // FINAL_FRAME_RENDERED_CHANGED_EVENT which our camera animation
+        // can trigger, causing restoreState to resolve before the
+        // visibility reset completes — then its delayed completion
+        // overwrites the new visibility state we set next.
+        const filter = { viewport: false };
+        this.viewer.restoreState(state, filter, true);
 
         let mapped3dItems = linked3dModel.mapped3dItems;
 

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -207,11 +207,20 @@ export class ForgeContext {
         }
         viewerState.renderOptions.appearance.progressiveDisplay = false;
 
-        // Lock navigation during restoreState's camera animation to
-        // prevent user orbit input from fighting the transition.
-        (this.viewer.navigation as any).setIsLocked(true);
-        await this.restoreState(viewerState);
-        (this.viewer.navigation as any).setIsLocked(false);
+        // Block pointer events during the animation to prevent user
+        // orbit from fighting the restoreState transition (fly-off).
+        // Re-enable after the animation completes or on any user
+        // interaction attempt (so it doesn't feel unresponsive).
+        this._element.style.pointerEvents = 'none';
+        const unblock = () => { this._element.style.pointerEvents = ''; };
+        this._element.addEventListener('pointerdown', unblock, { once: true, capture: true });
+
+        try {
+            await this.restoreState(viewerState);
+        } finally {
+            unblock();
+            this._element.removeEventListener('pointerdown', unblock, { capture: true });
+        }
         this.setPivotPoint();
     }
 

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -216,7 +216,11 @@ export class ForgeContext {
         this._element.addEventListener('pointerdown', unblock, { once: true, capture: true });
 
         try {
-            await this.restoreState(viewerState);
+            // Only restore the viewport (camera), not the full state.
+            // The saved camera state JSON includes objectSet/visibility
+            // from when it was captured — restoring that would overwrite
+            // the current visibility with stale data.
+            await this.restoreState(viewerState, { cameraOnly: true });
         } finally {
             unblock();
             this._element.removeEventListener('pointerdown', unblock, { capture: true });
@@ -224,7 +228,10 @@ export class ForgeContext {
         this.setPivotPoint();
     }
 
-    private restoreState(targetState: ViewerState, options?: { preserveCamera?: boolean }): Promise<void> {
+    private restoreState(
+        targetState: ViewerState,
+        options?: { preserveCamera?: boolean; cameraOnly?: boolean },
+    ): Promise<void> {
         // https://forge.autodesk.com/blog/wait-restorestate-finish
         return new Promise<void>((resolve) => {
             const listener = (event: any) => {
@@ -242,7 +249,12 @@ export class ForgeContext {
                 listener
             );
 
-            const filter = options?.preserveCamera ? { viewport: false } : undefined;
+            let filter: any;
+            if (options?.preserveCamera) {
+                filter = { viewport: false };
+            } else if (options?.cameraOnly) {
+                filter = { objectSet: false, renderOptions: false, cutplanes: false };
+            }
             this.viewer.restoreState(targetState, filter, false);
         });
     }

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -3,7 +3,7 @@ import { FootprintManager } from "./footprintManager";
 import { Label3DManager as LabelManager } from "./labelmanager";
 import { ViewerProgressEvent } from "./models/progressEvent";
 import { NameLabelsManager } from "./nameLabelsManager";
-import { ViewerState } from "./viewerState";
+import { ViewerState, Viewport } from "./viewerState";
 import { GeometryLoadedEvent } from "./models/geometryLoadedEvent";
 
 export class ForgeContext {
@@ -199,14 +199,12 @@ export class ForgeContext {
 
     private static CAMERA_ANIM_MS = 600;
 
-    private animateCamera(target: import("./viewerState").Viewport): Promise<void> {
-        // Cancel any in-flight animation
+    private animateCamera(target: Viewport): Promise<void> {
         this._cancelCameraAnimation?.();
 
         const nav = this.viewer.navigation;
         const cam = nav.getCamera();
 
-        // Snapshot the starting pose
         const startEye = cam.position.clone();
         const startTarget = (cam as any).target.clone();
         const startUp = cam.up.clone();
@@ -215,12 +213,10 @@ export class ForgeContext {
         const endTarget = new THREE.Vector3(target.target[0], target.target[1], target.target[2]);
         const endUp = new THREE.Vector3(target.up[0], target.up[1], target.up[2]);
 
-        // If positions are (nearly) identical, apply immediately
         if (startEye.distanceTo(endEye) < 0.01 && startTarget.distanceTo(endTarget) < 0.01) {
             cam.up.copy(endUp);
             nav.setPosition(endEye);
             nav.setTarget(endTarget);
-            this.setPivotPoint();
             return Promise.resolve();
         }
 
@@ -235,27 +231,29 @@ export class ForgeContext {
                 this._element.removeEventListener('mousedown', onInteract);
                 this._element.removeEventListener('touchstart', onInteract);
                 this._cancelCameraAnimation = null;
-                this.setPivotPoint();
                 resolve();
             };
 
             const onInteract = () => { finish(); };
 
-            this._element.addEventListener('mousedown', onInteract, { once: true });
-            this._element.addEventListener('touchstart', onInteract, { once: true });
+            this._element.addEventListener('mousedown', onInteract);
+            this._element.addEventListener('touchstart', onInteract);
 
             this._cancelCameraAnimation = finish;
+
+            const eye = new THREE.Vector3();
+            const tgt = new THREE.Vector3();
+            const up = new THREE.Vector3();
 
             const tick = (now: number) => {
                 if (cancelled) return;
                 const elapsed = now - t0;
-                // Ease-out quadratic
                 const raw = Math.min(elapsed / ForgeContext.CAMERA_ANIM_MS, 1);
                 const t = 1 - (1 - raw) * (1 - raw);
 
-                const eye = new THREE.Vector3().lerpVectors(startEye, endEye, t);
-                const tgt = new THREE.Vector3().lerpVectors(startTarget, endTarget, t);
-                const up = new THREE.Vector3().lerpVectors(startUp, endUp, t).normalize();
+                eye.lerpVectors(startEye, endEye, t);
+                tgt.lerpVectors(startTarget, endTarget, t);
+                up.lerpVectors(startUp, endUp, t).normalize();
 
                 cam.up.copy(up);
                 nav.setPosition(eye);

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -3,7 +3,7 @@ import { FootprintManager } from "./footprintManager";
 import { Label3DManager as LabelManager } from "./labelmanager";
 import { ViewerProgressEvent } from "./models/progressEvent";
 import { NameLabelsManager } from "./nameLabelsManager";
-import { ViewerState } from "./viewerState";
+import { ViewerState, Viewport } from "./viewerState";
 import { GeometryLoadedEvent } from "./models/geometryLoadedEvent";
 
 export class ForgeContext {
@@ -188,6 +188,8 @@ export class ForgeContext {
         return p;
     }
 
+    private static CAMERA_ANIM_MS = 600;
+
     private async applyCameraInternal(camera: CameraPosition, configurationId: string | null): Promise<void> {
         if (!camera.state) { return; }
 
@@ -205,30 +207,76 @@ export class ForgeContext {
                 viewerState.viewport.eye[2] += settings.z;
             }
         }
-        viewerState.renderOptions.appearance.progressiveDisplay = false;
 
-        // Block pointer events during the animation to prevent user
-        // orbit from fighting the restoreState transition (fly-off).
-        // Re-enable after the animation completes or on any user
-        // interaction attempt (so it doesn't feel unresponsive).
-        this._element.style.pointerEvents = 'none';
-        const unblock = () => { this._element.style.pointerEvents = ''; };
-        this._element.addEventListener('pointerdown', unblock, { once: true, capture: true });
-
-        // Only restore the viewport (camera). The saved state JSON
-        // includes objectSet/visibility from when it was captured —
-        // restoring that would overwrite current visibility with stale
-        // data. Merge our target viewport into the current live state.
-        const liveState = this.viewer.getState();
-        liveState.viewport = viewerState.viewport;
-
-        try {
-            await this.restoreState(liveState);
-        } finally {
-            unblock();
-            this._element.removeEventListener('pointerdown', unblock, { capture: true });
-        }
+        // Animate using direct navigation API — never restoreState.
+        // restoreState applies the full viewer state (including
+        // visibility/objectSet), which overwrites current visibility
+        // and causes "one update behind" bugs.
+        await this.animateCamera(viewerState.viewport);
         this.setPivotPoint();
+    }
+
+    private animateCamera(target: Viewport): Promise<void> {
+        const nav = this.viewer.navigation;
+        const cam = nav.getCamera();
+
+        const startEye = cam.position.clone();
+        const startTarget = (cam as any).target.clone();
+        const startUp = cam.up.clone();
+
+        const endEye = new THREE.Vector3(target.eye[0], target.eye[1], target.eye[2]);
+        const endTarget = new THREE.Vector3(target.target[0], target.target[1], target.target[2]);
+        const endUp = new THREE.Vector3(target.up[0], target.up[1], target.up[2]);
+
+        return new Promise<void>((resolve) => {
+            let cancelled = false;
+            let rafId: number;
+            const t0 = performance.now();
+
+            const finish = () => {
+                if (cancelled) return;
+                cancelled = true;
+                cancelAnimationFrame(rafId);
+                this._element.removeEventListener('pointerdown', onInteract);
+                this._element.removeEventListener('wheel', onInteract);
+                this.setPivotPoint();
+                resolve();
+            };
+
+            const onInteract = () => { finish(); };
+
+            // Cancel on user interaction so orbit takes over cleanly
+            this._element.addEventListener('pointerdown', onInteract);
+            this._element.addEventListener('wheel', onInteract);
+
+            const eye = new THREE.Vector3();
+            const tgt = new THREE.Vector3();
+            const up = new THREE.Vector3();
+
+            const tick = (now: number) => {
+                if (cancelled) return;
+                const elapsed = now - t0;
+                // Ease-out quadratic
+                const raw = Math.min(elapsed / ForgeContext.CAMERA_ANIM_MS, 1);
+                const t = 1 - (1 - raw) * (1 - raw);
+
+                eye.lerpVectors(startEye, endEye, t);
+                tgt.lerpVectors(startTarget, endTarget, t);
+                up.lerpVectors(startUp, endUp, t).normalize();
+
+                cam.up.copy(up);
+                nav.setPosition(eye);
+                nav.setTarget(tgt);
+
+                if (raw < 1) {
+                    rafId = requestAnimationFrame(tick);
+                } else {
+                    finish();
+                }
+            };
+
+            rafId = requestAnimationFrame(tick);
+        });
     }
 
     private restoreState(

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -423,7 +423,7 @@ export class ForgeContext {
 
         this.moveModel(model, linked3dModel);
 
-        let instanceTree = this.viewer.model.getData().instanceTree;
+        let instanceTree = model.getData().instanceTree;
 
         for (let visibleItem of mapped3dItems.visibleItems) {
             let itemIds = this.dbIdsByName[model.id][visibleItem.toLowerCase()];
@@ -454,7 +454,7 @@ export class ForgeContext {
         }
         for (let fragId in this.originalColors) {
             let color = this.originalColors[fragId];
-            let material = (<any>this.viewer.model.getFragmentList()).getMaterial(fragId);
+            let material = (<any>model.getFragmentList()).getMaterial(fragId);
             material.color = color;
             material.needsUpdate = true;
         }
@@ -471,7 +471,7 @@ export class ForgeContext {
                     const frags = this.dbsToFrags([itemId]);
 
                     for (const fragId of frags) {
-                        let originalMaterial = (<any>this.viewer.model.getFragmentList()).getMaterial(fragId);
+                        let originalMaterial = (<any>model.getFragmentList()).getMaterial(fragId);
                         if (originalMaterial) {
                             if (!(fragId in this.originalMaterials)) {
                                 this.originalMaterials[fragId] = originalMaterial;

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -226,18 +226,20 @@ export class ForgeContext {
             const t0 = performance.now();
 
             const finish = () => {
+                if (cancelled) return;
                 cancelled = true;
                 cancelAnimationFrame(rafId);
-                this._element.removeEventListener('mousedown', onInteract);
-                this._element.removeEventListener('touchstart', onInteract);
+                this._element.removeEventListener('pointerdown', onInteract);
+                this._element.removeEventListener('wheel', onInteract);
                 this._cancelCameraAnimation = null;
                 resolve();
             };
 
             const onInteract = () => { finish(); };
 
-            this._element.addEventListener('mousedown', onInteract);
-            this._element.addEventListener('touchstart', onInteract);
+            // pointerdown covers mouse, touch, and pen input
+            this._element.addEventListener('pointerdown', onInteract);
+            this._element.addEventListener('wheel', onInteract);
 
             this._cancelCameraAnimation = finish;
 

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -18,6 +18,7 @@ export class ForgeContext {
     public loaded3dModels: { [configurationId: string]: Autodesk.Viewing.Model } = {};
     public linked3dSettings: { [configurationId: string]: Layout3d } = {};
     private dbIdsByName: { [modelId: number]: { [name: string]: number[] } } = {};
+    private _cancelCameraAnimation: (() => void) | null = null;
     private onLoadStart: ((event: Layout3d) => void) | null;
 
     constructor() { }
@@ -185,8 +186,90 @@ export class ForgeContext {
             }
         }
         viewerState.renderOptions.appearance.progressiveDisplay = false;
-        await this.restoreState(viewerState);
+
+        // Animate the camera using our own lerp loop instead of
+        // restoreState. restoreState's internal animation conflicts
+        // with user orbit — if the user drags during the transition
+        // both fight over the camera, causing a fly-off. Our loop
+        // cancels instantly on user interaction so the orbit tool
+        // takes over cleanly from wherever the camera is.
+        await this.animateCamera(viewerState.viewport);
         this.setPivotPoint();
+    }
+
+    private static CAMERA_ANIM_MS = 600;
+
+    private animateCamera(target: import("./viewerState").Viewport): Promise<void> {
+        // Cancel any in-flight animation
+        this._cancelCameraAnimation?.();
+
+        const nav = this.viewer.navigation;
+        const cam = nav.getCamera();
+
+        // Snapshot the starting pose
+        const startEye = cam.position.clone();
+        const startTarget = (cam as any).target.clone();
+        const startUp = cam.up.clone();
+
+        const endEye = new THREE.Vector3(target.eye[0], target.eye[1], target.eye[2]);
+        const endTarget = new THREE.Vector3(target.target[0], target.target[1], target.target[2]);
+        const endUp = new THREE.Vector3(target.up[0], target.up[1], target.up[2]);
+
+        // If positions are (nearly) identical, apply immediately
+        if (startEye.distanceTo(endEye) < 0.01 && startTarget.distanceTo(endTarget) < 0.01) {
+            cam.up.copy(endUp);
+            nav.setPosition(endEye);
+            nav.setTarget(endTarget);
+            this.setPivotPoint();
+            return Promise.resolve();
+        }
+
+        return new Promise<void>((resolve) => {
+            let cancelled = false;
+            let rafId: number;
+            const t0 = performance.now();
+
+            const finish = () => {
+                cancelled = true;
+                cancelAnimationFrame(rafId);
+                this._element.removeEventListener('mousedown', onInteract);
+                this._element.removeEventListener('touchstart', onInteract);
+                this._cancelCameraAnimation = null;
+                this.setPivotPoint();
+                resolve();
+            };
+
+            const onInteract = () => { finish(); };
+
+            this._element.addEventListener('mousedown', onInteract, { once: true });
+            this._element.addEventListener('touchstart', onInteract, { once: true });
+
+            this._cancelCameraAnimation = finish;
+
+            const tick = (now: number) => {
+                if (cancelled) return;
+                const elapsed = now - t0;
+                // Ease-out quadratic
+                const raw = Math.min(elapsed / ForgeContext.CAMERA_ANIM_MS, 1);
+                const t = 1 - (1 - raw) * (1 - raw);
+
+                const eye = new THREE.Vector3().lerpVectors(startEye, endEye, t);
+                const tgt = new THREE.Vector3().lerpVectors(startTarget, endTarget, t);
+                const up = new THREE.Vector3().lerpVectors(startUp, endUp, t).normalize();
+
+                cam.up.copy(up);
+                nav.setPosition(eye);
+                nav.setTarget(tgt);
+
+                if (raw < 1) {
+                    rafId = requestAnimationFrame(tick);
+                } else {
+                    finish();
+                }
+            };
+
+            rafId = requestAnimationFrame(tick);
+        });
     }
 
     private restoreState(targetState: ViewerState, options?: { preserveCamera?: boolean }): Promise<void> {

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -405,6 +405,21 @@ export class ForgeContext {
     private async toggleInViewer(model: Autodesk.Viewing.Model, linked3dModel: Layout3d) {
         if (!this.viewer) { return; }
 
+        // Wait for the object tree to be mapped if it hasn't been yet.
+        // loadModel resolves before onObjectTreeCreated fires, so
+        // dbIdsByName may not be populated on first call.
+        if (!this.dbIdsByName[model.id]) {
+            await new Promise<void>((resolve) => {
+                const check = (e: any) => {
+                    if (e.model.id === model.id) {
+                        this.viewer.removeEventListener(Autodesk.Viewing.OBJECT_TREE_CREATED_EVENT, check);
+                        resolve();
+                    }
+                };
+                this.viewer.addEventListener(Autodesk.Viewing.OBJECT_TREE_CREATED_EVENT, check);
+            });
+        }
+
         const state = this.viewer.getState();
         for (const objSet of state.objectSet) {
             objSet.hidden = [];

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -19,6 +19,7 @@ export class ForgeContext {
     public linked3dSettings: { [configurationId: string]: Layout3d } = {};
     private dbIdsByName: { [modelId: number]: { [name: string]: number[] } } = {};
     private onLoadStart: ((event: Layout3d) => void) | null;
+    private _applyCameraPromise: Promise<void> | null = null;
 
     constructor() { }
 
@@ -135,6 +136,15 @@ export class ForgeContext {
                 return;
             }
 
+            // Wait for any in-flight camera animation to finish before
+            // proceeding. Both applyCamera and toggleInViewer use
+            // restoreState which listens for FINAL_FRAME_RENDERED_CHANGED_EVENT
+            // — running them concurrently causes one to prematurely
+            // resolve the other.
+            if (this._applyCameraPromise) {
+                await this._applyCameraPromise;
+            }
+
             for (let configurationId of Object.keys(this.loaded3dModels)) {
                 if (!layout3d.some(l => l.configurationId == configurationId)) {
                     this.viewer.hideModel(this.loaded3dModels[configurationId].id);
@@ -167,7 +177,18 @@ export class ForgeContext {
         return promise;
     }
 
-    public async applyCamera(camera: CameraPosition, configurationId: string | null = null): Promise<void> {
+    public applyCamera(camera: CameraPosition, configurationId: string | null = null): Promise<void> {
+        const p = this.applyCameraInternal(camera, configurationId);
+        this._applyCameraPromise = p;
+        p.finally(() => {
+            if (this._applyCameraPromise === p) {
+                this._applyCameraPromise = null;
+            }
+        });
+        return p;
+    }
+
+    private async applyCameraInternal(camera: CameraPosition, configurationId: string | null): Promise<void> {
         if (!camera.state) { return; }
 
         let viewerState = JSON.parse(camera.state) as ViewerState;

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -3,7 +3,7 @@ import { FootprintManager } from "./footprintManager";
 import { Label3DManager as LabelManager } from "./labelmanager";
 import { ViewerProgressEvent } from "./models/progressEvent";
 import { NameLabelsManager } from "./nameLabelsManager";
-import { ViewerState, Viewport } from "./viewerState";
+import { ViewerState } from "./viewerState";
 import { GeometryLoadedEvent } from "./models/geometryLoadedEvent";
 
 export class ForgeContext {
@@ -18,7 +18,6 @@ export class ForgeContext {
     public loaded3dModels: { [configurationId: string]: Autodesk.Viewing.Model } = {};
     public linked3dSettings: { [configurationId: string]: Layout3d } = {};
     private dbIdsByName: { [modelId: number]: { [name: string]: number[] } } = {};
-    private _cancelCameraAnimation: (() => void) | null = null;
     private onLoadStart: ((event: Layout3d) => void) | null;
 
     constructor() { }
@@ -136,11 +135,6 @@ export class ForgeContext {
                 return;
             }
 
-            // Cancel any in-flight camera animation so its per-frame
-            // renders don't trigger FINAL_FRAME_RENDERED_CHANGED_EVENT
-            // and prematurely resolve the restoreState in toggleInViewer.
-            this._cancelCameraAnimation?.();
-
             for (let configurationId of Object.keys(this.loaded3dModels)) {
                 if (!layout3d.some(l => l.configurationId == configurationId)) {
                     this.viewer.hideModel(this.loaded3dModels[configurationId].id);
@@ -192,84 +186,13 @@ export class ForgeContext {
         }
         viewerState.renderOptions.appearance.progressiveDisplay = false;
 
-        // Animate the camera using our own lerp loop instead of
-        // restoreState. restoreState's internal animation conflicts
-        // with user orbit — if the user drags during the transition
-        // both fight over the camera, causing a fly-off. Our loop
-        // cancels instantly on user interaction so the orbit tool
-        // takes over cleanly from wherever the camera is.
-        await this.animateCamera(viewerState.viewport);
+        // Lock navigation during restoreState's camera animation to
+        // prevent user orbit input from fighting the transition.
+        (this.viewer.navigation as any).setIsLocked(true);
+        await this.restoreState(viewerState);
+        (this.viewer.navigation as any).setIsLocked(false);
         this.setPivotPoint();
     }
-
-    private static CAMERA_ANIM_MS = 600;
-
-    private animateCamera(target: Viewport): Promise<void> {
-        this._cancelCameraAnimation?.();
-
-        const nav = this.viewer.navigation;
-        const cam = nav.getCamera();
-
-        const startEye = cam.position.clone();
-        const startTarget = (cam as any).target.clone();
-        const startUp = cam.up.clone();
-
-        const endEye = new THREE.Vector3(target.eye[0], target.eye[1], target.eye[2]);
-        const endTarget = new THREE.Vector3(target.target[0], target.target[1], target.target[2]);
-        const endUp = new THREE.Vector3(target.up[0], target.up[1], target.up[2]);
-
-        return new Promise<void>((resolve) => {
-            let cancelled = false;
-            let rafId: number;
-            const t0 = performance.now();
-
-            const finish = () => {
-                if (cancelled) return;
-                cancelled = true;
-                cancelAnimationFrame(rafId);
-                this._element.removeEventListener('pointerdown', onInteract);
-                this._element.removeEventListener('wheel', onInteract);
-                this._cancelCameraAnimation = null;
-                resolve();
-            };
-
-            const onInteract = () => { finish(); };
-
-            // pointerdown covers mouse, touch, and pen input
-            this._element.addEventListener('pointerdown', onInteract);
-            this._element.addEventListener('wheel', onInteract);
-
-            this._cancelCameraAnimation = finish;
-
-            const eye = new THREE.Vector3();
-            const tgt = new THREE.Vector3();
-            const up = new THREE.Vector3();
-
-            const tick = (now: number) => {
-                if (cancelled) return;
-                const elapsed = now - t0;
-                const raw = Math.min(elapsed / ForgeContext.CAMERA_ANIM_MS, 1);
-                const t = 1 - (1 - raw) * (1 - raw);
-
-                eye.lerpVectors(startEye, endEye, t);
-                tgt.lerpVectors(startTarget, endTarget, t);
-                up.lerpVectors(startUp, endUp, t).normalize();
-
-                cam.up.copy(up);
-                nav.setPosition(eye);
-                nav.setTarget(tgt);
-
-                if (raw < 1) {
-                    rafId = requestAnimationFrame(tick);
-                } else {
-                    finish();
-                }
-            };
-
-            rafId = requestAnimationFrame(tick);
-        });
-    }
-
 
     private restoreState(targetState: ViewerState, options?: { preserveCamera?: boolean }): Promise<void> {
         // https://forge.autodesk.com/blog/wait-restorestate-finish

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -215,12 +215,15 @@ export class ForgeContext {
         const unblock = () => { this._element.style.pointerEvents = ''; };
         this._element.addEventListener('pointerdown', unblock, { once: true, capture: true });
 
+        // Only restore the viewport (camera). The saved state JSON
+        // includes objectSet/visibility from when it was captured —
+        // restoring that would overwrite current visibility with stale
+        // data. Merge our target viewport into the current live state.
+        const liveState = this.viewer.getState();
+        liveState.viewport = viewerState.viewport;
+
         try {
-            // Only restore the viewport (camera), not the full state.
-            // The saved camera state JSON includes objectSet/visibility
-            // from when it was captured — restoring that would overwrite
-            // the current visibility with stale data.
-            await this.restoreState(viewerState, { cameraOnly: true });
+            await this.restoreState(liveState);
         } finally {
             unblock();
             this._element.removeEventListener('pointerdown', unblock, { capture: true });
@@ -230,7 +233,7 @@ export class ForgeContext {
 
     private restoreState(
         targetState: ViewerState,
-        options?: { preserveCamera?: boolean; cameraOnly?: boolean },
+        options?: { preserveCamera?: boolean },
     ): Promise<void> {
         // https://forge.autodesk.com/blog/wait-restorestate-finish
         return new Promise<void>((resolve) => {
@@ -249,12 +252,7 @@ export class ForgeContext {
                 listener
             );
 
-            let filter: any;
-            if (options?.preserveCamera) {
-                filter = { viewport: false };
-            } else if (options?.cameraOnly) {
-                filter = { objectSet: false, renderOptions: false, cutplanes: false };
-            }
+            const filter = options?.preserveCamera ? { viewport: false } : undefined;
             this.viewer.restoreState(targetState, filter, false);
         });
     }


### PR DESCRIPTION
## Summary

- Replace `restoreState` in `applyCamera` with a custom `requestAnimationFrame` lerp loop
- The Autodesk Viewer's `restoreState` sets up an internal camera animation that conflicts with user orbit (drag-to-rotate) — if the user interacts before the animation completes, both fight over camera control causing the model to fly off screen
- The new animation cancels instantly on `mousedown`/`touchstart`, letting the orbit tool take over cleanly from the current interpolated position
- Skips animation entirely when positions are nearly identical
- Cancels any in-flight animation when a new one starts
- 600ms ease-out quadratic, matching the original feel
- Bumps version to 1.4.0

## Test plan

- [ ] Switching configurator steps with different camera angles shows smooth animation
- [ ] Dragging to rotate during camera animation stops the animation and orbits normally (no fly-off)
- [ ] Feature selection with camera positions transitions smoothly
- [ ] Rapid step switching doesn't leave stale animations running
- [ ] Camera home button still works