### PR TITLE
Revert SVF2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfsquad/forge-viewer",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/elfsquad-forge-viewer.ts
+++ b/src/elfsquad-forge-viewer.ts
@@ -66,13 +66,12 @@ export class ElfsquadForgeViewer extends HTMLElement {
         layout3d: Layout3d[], 
         onProgess: ((event: ViewerProgressEvent) => void) | null = null,
         onLoadStart: ((event: Layout3d) => void) | null = null,
-        onLoadEnd: ((event: GeometryLoadedEvent) => void) | null = null,
-        useStreaming: boolean = false
+        onLoadEnd: ((event: GeometryLoadedEvent) => void) | null = null
         ): Promise<void> {
         if (!this._viewerContainerDiv) return;
 
         this._forgeContext = new ForgeContext();
-        await this._forgeContext.initialize(this._viewerContainerDiv, onProgess, onLoadStart, onLoadEnd, useStreaming);    
+        await this._forgeContext.initialize(this._viewerContainerDiv, onProgess, onLoadStart, onLoadEnd);
 
         
         this._forgeContext.nameLabelsManager.onConfigurationSelected = (configurationId) => {

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -26,8 +26,7 @@ export class ForgeContext {
         element: HTMLElement,
         onProgess: ((event: ViewerProgressEvent) => void) | null = null,
         onLoadStart: ((event: Layout3d) => void) | null = null,
-        onLoadEnd: ((event: GeometryLoadedEvent) => void) | null = null,
-        useStreaming: boolean = false
+        onLoadEnd: ((event: GeometryLoadedEvent) => void) | null = null
     ): Promise<void> {
         if (typeof Autodesk == 'undefined') {
             throw Error(`Autodesk is not defined. Ensure you have loaded the required Autodesk Forge Viewer script from https://developer.api.autodesk.com/modelderivative/v2/viewers/7.*/viewer3D.min.js`);
@@ -35,7 +34,7 @@ export class ForgeContext {
 
         this._element = element;
         await this.initializeViewerToken();
-        await this.initializeViewer(this._element, onProgess, onLoadEnd, useStreaming);
+        await this.initializeViewer(this._element, onProgess, onLoadEnd);
         this.intializeNameLabelsManager();
         this.initializeLabelManager();
         this.initializeFootprintManager();
@@ -51,13 +50,11 @@ export class ForgeContext {
         this._token = await response.text();
     }
 
-    private initializeViewer(element: HTMLElement, onProgess: ((event: ViewerProgressEvent) => void) | null, onLoadEnd: ((event: GeometryLoadedEvent) => void) | null = null, useStreaming : boolean = false): Promise<void> {
-        (<any>window).USE_OPFS = true; //https://aps.autodesk.com/blog/viewer-performance-update-part-2-3-opfs-caching
+    private initializeViewer(element: HTMLElement, onProgess: ((event: ViewerProgressEvent) => void) | null, onLoadEnd: ((event: GeometryLoadedEvent) => void) | null = null): Promise<void> {
         let promise = new Promise<void>((resolve, _) => {
 
             Autodesk.Viewing.Initializer({
-                env: 'AutodeskProduction2',
-                api: useStreaming ? 'streamingV2_EU' : 'derivativeV2',
+                env: 'AutodeskProduction',
                 accessToken: this._token as string
             }, () => {
                 this.viewer = new Autodesk.Viewing.Viewer3D(element, {});
@@ -235,30 +232,25 @@ export class ForgeContext {
                 `urn:${layout3d.urn}`,
                 async (viewerDocument) => {
                     if (this.viewer == null) return;
-            
+
                     this._loadModelPromises[layout3d.configurationId] = { resolve, reject };
                     this._layouts[viewerDocument.docRoot.id] = layout3d;
 
-                    const root = viewerDocument.getRoot();
-            
-                    this.viewer.loadModel(viewerDocument.getViewablePath(root.getDefaultGeometry()), {
+                    const defaultModel = viewerDocument.getRoot().getDefaultGeometry();
+                    this.viewer.loadModel(viewerDocument.getViewablePath(defaultModel), {
                         applyScaling: 'mm',
-                        loadAsHidden: true,
-                        acmSessionId: viewerDocument.acmSessionId
+                        loadAsHidden: true
                     },
-                    (model) => {
-                        this.loaded3dModels[layout3d.configurationId] = model;
-                        this.moveModel(model, layout3d);
-                        resolve(model);
-                    });
-            
+                        (model) => {
+                            this.loaded3dModels[layout3d.configurationId] = model;
+                            this.moveModel(model, layout3d);
+                        });
+
                 },
                 (err) => {
                     console.error('document load error', err)
                     reject(err);
-                }
-            );
-            
+                });
         });
 
         return promise;


### PR DESCRIPTION
## Summary
- Reverts SVF2/streaming API changes introduced by Anco on May 15, 2024 (commits 4b1264a, 9e5e211, 7397985, 9051aaf)
- Removes `useStreaming` parameter, `AutodeskProduction2` env, OPFS caching, and `acmSessionId` usage
- Restores original `AutodeskProduction` environment and model loading behavior
- Bumps version to 1.3.2

## Test plan
- [ ] Verify 3D models load correctly with the restored `AutodeskProduction` environment
- [ ] Confirm model loading spinner and geometry events work as before
- [ ] Test layout apply with multiple models

🤖 Generated with [Claude Code](https://claude.com/claude-code)