### PR TITLE
EC-24398: fix render loop hang in restoreState during demand-rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfsquad/forge-viewer",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/forge/forge-context.ts
+++ b/src/forge/forge-context.ts
@@ -209,6 +209,10 @@ export class ForgeContext {
             // overriding active camera transitions with intermediate states
             const filter = options?.preserveCamera ? { viewport: false } : undefined;
             this.viewer.restoreState(targetState, filter, false);
+
+            // Kick the render loop; without this the FINAL_FRAME_RENDERED_CHANGED_EVENT
+            // never fires when the viewer is idle (demand-rendering mode).
+            requestAnimationFrame(() => this.viewer.impl.invalidate(true));
         });
 
 


### PR DESCRIPTION
## Summary
- `restoreState()` waits for `FINAL_FRAME_RENDERED_CHANGED_EVENT` which never fires when the viewer is idle (demand-rendering mode), causing `update()` to hang indefinitely
- Added `requestAnimationFrame(() => this.viewer.impl.invalidate(true))` after `viewer.restoreState()` to ensure a render frame is produced
- Bumped version to 1.3.3

## Context
Consumers (e.g. [showroom](https://github.com/Elfsquad/showroom)) had to work around this by reaching into private internals (`_forgeContext.viewer.impl.invalidate`). This fix moves the responsibility into the library where it belongs.

See Elfsquad/showroom#107 for the original workaround.

## Test plan
- [ ] Open a 3D configuration, pick a color — viewer updates immediately
- [ ] Switch between 3D steps — no hang, camera transitions work
- [ ] Let viewer idle for a few seconds, then pick an option — still updates